### PR TITLE
bug: Fix silent failure when running via npx github:workos/migrate-clerk-users

### DIFF
--- a/bin/migrate-clerk-users.mjs
+++ b/bin/migrate-clerk-users.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { register } from "node:module";
+
+register("tsx/esm", import.meta.url);
+
+const { default: start } = await import("../src/index.ts");
+start();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "src/index.ts",
   "type": "module",
   "bin": {
-    "migrate-clerk-users": "bin/migrate-clerk-users.ts"
+    "migrate-clerk-users": "bin/migrate-clerk-users.mjs"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
# Summary

  - The bin entry pointed to a .ts file with a #!/usr/bin/env tsx shebang. When installed via npx
  github:workos/migrate-clerk-users, tsx isn't on the system PATH, causing a silent failure with
  exit code 1.
  - Replaced with a .mjs wrapper that uses Node's module.register() to load tsx/esm, so the tool
  works with plain node — no global tsx required.


 # Tested locally

  - npx <local-path> from /tmp (simulates npx github: install) — 1/1 user imported successfully
  - Local npx tsx bin/migrate-clerk-users.ts still works — 2/2 users imported
  - Tested with customer's actual CSV export file
  - Tested with example-input.csv